### PR TITLE
Keep original order of pronunciation variants (#1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ German IPA dictionary as extracted from wiktionary
 ## Generate de.csv from de.wiktionary
 
 - Download `dewiktionary-****-pages-meta-current.xml` dump from [Wikimedia](https://dumps.wikimedia.org/backup-index.html)
-- edit `extract_de_ipa.py` to pass the file location to `open()`
-- `$ ./extract_de_ipa.sh`
+- Change `INFILE` at the top of `extract_de_ipa.py` to point to the `.xml.bz2` file you downloaded
+- `$ python3 ./extract_de_ipa.py`
 
 ## Documentation
 

--- a/extract_de_ipa.sh
+++ b/extract_de_ipa.sh
@@ -1,2 +1,0 @@
-python3 ./extract_de_ipa.py  > de_dewikt_raw.csv
-LC_ALL=C sort -u -o de_dewikt.csv < de_dewikt_raw.csv


### PR DESCRIPTION
Fixes https://github.com/devio-at/german-ipa-dict/issues/1

Rather than writing to an intermediate file and then sort via `sort` in the shell script [extract_de_ipa.sh](https://github.com/devio-at/german-ipa-dict/blob/a08113e0ab80f049b625fc360196491f56243ca1/extract_de_ipa.sh), we collect the result rows in Python and sort there, but only considering the text in the first column (and not the IPA string), thus keeping the original order (on Wiktionary) of pronunciation variants for the same text (because [Python's list.sort()](https://docs.python.org/3/library/stdtypes.html#list.sort) is stable).

I also switched to writing the result file using Python's built-in `csv` library instead of just `print`ing result lines, because:
* We need to keep the columns separated in order to be able to sort at the end using only the first column. So `printIpa` is now called `buildRow` and returns a list of three strings (text, IPA, comments).
* Using the `csv` library takes care of quoting for us, so we don't need something like `return "\"" + s + "\"" if "," in s else s` anymore.
* Using the `csv` library makes the result file actually valid CSV. Until now, rows with a comment had three fields (two commas) and rows without a comment had only two fields (one comma). The new result can be read, e.g., by [pandas.read_csv](https://pandas.pydata.org/docs/reference/api/pandas.read_csv.html), which threw an error before, complaining about rows with incorrect number of fields.
* Writing to a result file in Python makes stdout free for `print`ing status and progress information, some of which I added.

Finally, I also switched from plain `open()` to `bz2.open()` so we don't need to decompress the file downloaded from Wikimedia before running the script.